### PR TITLE
OpenRC version of sendmail 

### DIFF
--- a/etc/conf.d/sendmail
+++ b/etc/conf.d/sendmail
@@ -1,0 +1,23 @@
+# sendmail config file, taken from old FreeBSD defaults/rc.conf
+#
+# Default of NO/YES/NO/NO starts up a localhost only MTA so
+# mail from cron gets to root
+#
+# run sendmail inbound daemon YES/NO
+sendmail_enable="NO"
+# start localhost only MTA for mail submission YES/NO
+sendmail_submit_enable="YES"
+# dequeue stuck mail YES/NO
+sendmail_outbound_enable="NO"
+# dequue stuck clientmail YES/NO
+sendmail_msp_queue_enable="NO"
+
+# Sendmail flags as a server
+sendmail_flags="-L sm-mta -bd -q30m" # Flags to sendmail (as a server)
+# Localhost MTA only flags
+sendmail_submit_flags="-L sm-mta -bd -q30m -ODaemonPortOptions=Addr=localhost"
+# Outbound only flags
+sendmail_outbound_flags="-L sm-queue -q30m" # Flags to sendmail (outbound only)
+# sendmail msp queue daemon flags
+sendmail_msp_queue_flags="-L sm-msp-queue -Ac -q30m"
+

--- a/etc/init.d/sendmail
+++ b/etc/init.d/sendmail
@@ -1,0 +1,233 @@
+#!/sbin/openrc-run
+# OpenRC version of FreeBSD rc.sendmail
+# Copyright (c) 2016
+# 2 Clause BSD license
+#
+# Copyright (c) 2002  Gregory Neil Shapiro.  All Rights Reserved.
+# Copyright (c) 2000, 2002  The FreeBSD Project
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+# $FreeBSD$
+#
+
+# This script is used by /etc/rc at boot time to start sendmail.  It
+# is meant to be sendmail specific and not a generic script for all
+# MTAs.  It is only called by /etc/rc if the rc.conf mta_start_script is
+# set to /etc/rc.sendmail.  This provides the opportunity for other MTAs
+# to provide their own startup script.
+
+# The script is also used by /etc/mail/Makefile to enable the
+# start/stop/restart targets.
+
+# The source for the script can be found in src/etc/sendmail/rc.sendmail.
+
+description="Sendmail startup script"
+name="sendmail"
+
+# The sendmail binary
+sendmail_program=${sendmail_program:-/usr/sbin/sendmail}
+extra_commands="start-mta stop-mta restart-mta start-mspq stop-mspq restart-mspq"
+
+# The pid is used to stop and restart the running daemon(s).
+sendmail_pidfile=${sendmail_pidfile:-/var/run/sendmail.pid}
+sendmail_mspq_pidfile=${sendmail_mspq_pidfile:-/var/spool/clientmqueue/sm-client.pid}
+depend()
+{
+    need net
+}
+start_mta()
+{
+	case ${sendmail_enable} in
+	[Nn][Oo][Nn][Ee])
+		;;
+	[Yy][Ee][Ss])
+		ebegin "Starting ${SVCNAME}"
+		start-stop-daemon --start --pidfile ${sendmail_pidfile} \
+                                  --exec ${sendmail_program} -- ${sendmail_flags}
+                eend $?
+		;;
+	*)
+		case ${sendmail_submit_enable} in
+		[Yy][Ee][Ss])
+			ebegin "Starting sendmail-submit"
+			start-stop-daemon --start --pidfile ${sendmail_pidfile} \
+                                          --exec ${sendmail_program} -- ${sendmail_submit_flags}
+                        eend $?
+			;;
+		*)
+			case ${sendmail_outbound_enable} in
+			[Yy][Ee][Ss])
+				ebegin "Starting sendmail-outbound"
+				start-stop-daemon --start --pidfile ${sendmail_pidfile} \
+                                                  --exec ${sendmail_program} -- ${sendmail_outbound_flags}
+                                eend $?
+				;;
+			esac
+			;;
+		esac
+		;;
+	esac
+}
+
+stop_mta()
+{
+	# Check to make sure we are configured to start an MTA
+	case ${sendmail_enable} in
+	[Nn][Oo][Nn][Ee])
+		return
+		;;
+	[Yy][Ee][Ss])
+		;;
+	*)
+		case ${sendmail_submit_enable} in
+		[Yy][Ee][Ss])
+			;;
+		*)
+			case ${sendmail_outbound_enable} in
+			[Yy][Ee][Ss])
+				;;
+			*)
+				return
+				;;
+			esac
+			;;
+		esac
+		;;
+	esac
+
+        ebegin "Stopping ${SVCNAME}"
+        start-stop-daemon --stop --pidfile ${sendmail_pidfile}
+        eend $?
+}
+
+restart_mta()
+{
+	# Check to make sure we are configured to start an MTA
+	case ${sendmail_enable} in
+	[Nn][Oo][Nn][Ee])
+		return
+		;;
+	[Yy][Ee][Ss])
+		;;
+	*)
+		case ${sendmail_submit_enable} in
+		[Yy][Ee][Ss])
+			;;
+		*)
+			case ${sendmail_outbound_enable} in
+			[Yy][Ee][Ss])
+				;;
+			*)
+				return
+				;;
+			esac
+			;;
+		esac
+		;;
+	esac
+        ebegin "Restart-mta"
+        start-stop-daemon --signal HUP --pidfile ${sendmail_pidfile}
+        eend $?
+}
+
+start_mspq()
+{
+	case ${sendmail_enable} in
+	[Nn][Oo][Nn][Ee])
+		;;
+	*)
+		if [ -r /etc/mail/submit.cf ]; then
+			case ${sendmail_msp_queue_enable} in
+			[Yy][Ee][Ss])
+				ebegin "Starting sendmail-clientmqueue"
+				start-stop-daemon --start --pidfile ${sendmail_mspq_pidfile} \
+                                                  --exec ${sendmail_program} -- ${sendmail_msp_queue_flags}
+				;;
+			esac
+		fi
+		;;
+	esac
+}
+
+stop_mspq()
+{
+	# Check to make sure we are configured to start an MSP queue runner
+	case ${sendmail_enable} in
+	[Nn][Oo][Nn][Ee])
+		return
+		;;
+	*)
+		if [ -r /etc/mail/submit.cf ]; then
+			case ${sendmail_msp_queue_enable} in
+			[Yy][Ee][Ss])
+				;;
+			*)
+				return
+				;;
+			esac
+		fi
+		;;
+	esac
+
+        ebegin "Stopping sendmail-clientmqueue"
+        start-stop-daemon --stop --pidfile ${sendmail_mspq_pidfile}
+        eend $?
+}
+
+restart_mspq()
+{
+	# Check to make sure we are configured to start an MSP queue runner
+	case ${sendmail_enable} in
+	[Nn][Oo][Nn][Ee])
+		return
+		;;
+	*)
+		if [ -r /etc/mail/submit.cf ]; then
+			case ${sendmail_msp_queue_enable} in
+			[Yy][Ee][Ss])
+				;;
+			*)
+				return
+				;;
+			esac
+		fi
+		;;
+	esac
+
+        ebegin "restarting sendmail-clientmqueue"
+        start-stop-daemon --signal HUP --pidfile  ${sendmail_mspq_pidfile}
+        eend $?
+}
+
+start()
+{
+    start_mta
+    start_mspq
+}
+
+stop()
+{
+    stop_mta
+    stop_mspq
+}


### PR DESCRIPTION
Started with FreeBSD rc.sendmail and vars from defaults/rc.conf and created OpenRC version.
Verified that  service sendmail start/stop worked for the default config of localhost only MTA.