### PR TITLE
use a broadcast to determine if networking is online

### DIFF
--- a/etc/init.d/net-online
+++ b/etc/init.d/net-online
@@ -25,17 +25,10 @@ start ()
 
 	ebegin "Checking to see if the network is online"
 	rc=0
-	interfaces=${interfaces:-$(ifconfig -nl "ether")}
 	timeout=${timeout:-120}
 	[ "$timeout" -eq 0 ] && infinite=true || infinite=false
-	found=false
 	while $infinite || [ "$timeout" -gt 0 ]; do
-		for dev in ${interfaces}; do
-			if ifconfig "$dev" | grep "status:" | grep -E "active|associated" > /dev/null 2>&1; then
-				ifconfig "$dev" | grep "^[[:blank:]]inet " | grep " broadcast "  > /dev/null 2>&1 && { found=true; break; }
-			fi
-		done
-		[ $found = true ] && break
+		nc -uz 255.255.255.255 111 > /dev/null 2>&1 && break
 		sleep 1
 		: $((timeout -= 1))
 	done


### PR DESCRIPTION
probing the interface status for "[active|associated]" and set
"broadcast"  proved to be unreliable with DHCP and ypbind, which will
fail/hang if there was no active (i.e. working IP configuration)
interface at service startup. In this case with ypbind, login will hang
for several minutes.

Using a zero-length broadcast to an arbitrary port (111/rpc was chosen
randomly) doesn't make any further assumptions about the connection e.g.
about routing or firewalling. Broadcasts always succeed as soon as the
link-layer is up (= assigned and active IP configuration on the interface).
This does NOT imply the host can actually reach anything through that link;
veryfing this has to be done via include_ping_test if needed.