### PR TITLE
add net-online as service dependency; remove ypserv

### DIFF
--- a/etc/init.d/ypbind
+++ b/etc/init.d/ypbind
@@ -8,8 +8,7 @@ command_args="${nis_client_flags}"
 
 depend()
 {
-	need localmount
-	want ypserv
+	need localmount net-online
 	keyword -shutdown -stop
 }
 


### PR DESCRIPTION
add net-online as service dependency and remove ypserv, as it isn't needed on NIS clients and leads to error messages at boot because the /var/yp/DOMAINNAME directory is not present on clients.