### PR TITLE
add rpcbind as service dependency because nc needs it

### DIFF
--- a/etc/init.d/net-online
+++ b/etc/init.d/net-online
@@ -10,6 +10,7 @@ interval=${retest_interval:-2}
 
 depend()
 {
+	need rpcbind
 	after network
 	provide network-online
 }


### PR DESCRIPTION
nc, used in net-online to check if basic networking is ready/up,
requires rpcbind to be running.
RPCbind is usually started very early and already available when
net-online is triggered; but for the sake of correctness and to catch
possible special edge cases, we should add the dependency.

Also see this discussion for reference:
https://discourse.trueos.org/t/net-online-init-script/2533
(The initially described problem with openntpd is not related to
net-online or rpcbind!)