### PR TITLE
Update net-online

### DIFF
--- a/etc/init.d/net-online
+++ b/etc/init.d/net-online
@@ -32,7 +32,8 @@ check_online()
     mark_service_started net-online
     return 0
   else
-    mark_service_starting net-online
+    #Not ready yet
+    mark_service_inactive net-online
     return 1
   fi
 }


### PR DESCRIPTION
Make sure the "inactive" state is used rather than "starting" when network access is still not available. The "starting" status is automatically getting changed to "started" by OpenRC now it seems like.