### PR TITLE
Fix automountd OpenRC service

### DIFF
--- a/etc/init.d/automountd
+++ b/etc/init.d/automountd
@@ -1,16 +1,24 @@
 #!/sbin/openrc-run
 
 command=/usr/sbin/automountd
-command_args="-d"
+command_args="-i"
 name="automountd"
-pidfile="/var/run/automountdaemond.pid"
-supervisor=supervise-daemon
-supervise_daemon_args="-1 /var/log/automountdaemond.log -2 /var/log/automountdaemond.log"
+pidfile="/var/run/automountd.pid"
+output_log="/var/log/automountd_service.log"
+error_log=${output_log}
+
+#Using supervise-daemon (NOT WORKING: automountd in non-daemon mode exits after one run)
+#command_args_foreground="-d"
+#supervisor=supervise-daemon
+
+#Using start-stop-daemon
+command_background="true"
 
 depend()
 {
-        need localmount
+        need nfsclient localmount
 	provide automountd
         use net logger dns
         before inetd xinetd
 }
+


### PR DESCRIPTION
* Switch this back to start-stop-daemon
* Have start-stop-daemon automatically background itself (needed for log output via OpenRC)
* Switch the pidfile to the automountd daemon's pidfile (so the service can properly see if it is running and/or stop it)

The impetus for this is that the "do not daemonize" flag in automountd (-d flag) also results in automountd **exiting** after handling a single mount (with return code 0). This renders the supervise-daemon unuseable at the moment because it is not getting a "crash" from automountd, just that it is exiting normally.